### PR TITLE
Improve move sound timing and stop end sounds on new game

### DIFF
--- a/tictak.xcodeproj/xcuserdata/leonardonapoles.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/tictak.xcodeproj/xcuserdata/leonardonapoles.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Bucket
+   uuid = "89F3E573-DF16-45FA-A3BA-96C9FDAE28C6"
+   type = "1"
+   version = "2.0">
+</Bucket>

--- a/tictak/AudioService.swift
+++ b/tictak/AudioService.swift
@@ -1,30 +1,74 @@
-//
-//  AudioService.swift
-//  tictak
-//
-//  Created by Leonardo Nápoles on 9/18/25.
-//
-
 import Foundation
 import AVFoundation
 
-class AudioService {
-    private var audioPlayer: AVAudioPlayer?
-    
-    func playSound(named fileName: String) {
-        guard let url = Bundle.main.url(forResource: fileName.components(separatedBy: ".").first, withExtension: fileName.components(separatedBy: ".").last)
-        else {
-            print("error: sound file '\(fileName)' not found.")
-            return
-        }
-        
+final class AudioService {
+    private let session = AVAudioSession.sharedInstance()
+    private var pools: [String: [AVAudioPlayer]] = [:]
+    private var hold: AVAudioPlayer?
+    private let queue = DispatchQueue(label: "AudioService.pool")
+
+    init() {
         do {
-            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
-            try AVAudioSession.sharedInstance().setActive(true)
-            audioPlayer = try AVAudioPlayer(contentsOf: url)
-            audioPlayer?.play()
-        } catch let error {
-            print("Error playing sound: \(error.localizedDescription)")
+            try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
+            try session.setActive(true)
+        } catch {
+            print("AudioService: audio session error: \(error.localizedDescription)")
+        }
+    }
+
+    func playSound(named fileName: String) {
+        guard let url = url(for: fileName) else { return }
+        fileName.contains("move") ? playPooled(file: fileName, url: url) : playOnce(url: url)
+    }
+
+    func stopNonMoveSounds() {
+        DispatchQueue.main.async { [weak self] in
+            self?.hold?.stop()
+            self?.hold = nil
+        }
+    }
+}
+
+private extension AudioService {
+    func url(for fileName: String) -> URL? {
+        let parts = fileName.split(separator: ".", maxSplits: 1).map(String.init)
+        guard parts.count == 2 else { return nil }
+        return Bundle.main.url(forResource: parts[0], withExtension: parts[1])
+    }
+
+    func makePlayer(url: URL) throws -> AVAudioPlayer {
+        let p = try AVAudioPlayer(contentsOf: url)
+        p.prepareToPlay()
+        p.currentTime = 0
+        return p
+    }
+
+    func playOnMain(_ player: AVAudioPlayer) {
+        DispatchQueue.main.async { player.play() }
+    }
+
+    func playPooled(file: String, url: URL) {
+        queue.async { [weak self] in
+            guard let self else { return }
+            var pool = self.pools[file, default: []]
+            if let p = pool.first(where: { !$0.isPlaying }) {
+                p.currentTime = 0
+                self.playOnMain(p)
+                self.pools[file] = pool
+                return
+            }
+            if let new = try? self.makePlayer(url: url) {
+                self.playOnMain(new)
+                pool.append(new)
+                self.pools[file] = pool
+            }
+        }
+    }
+
+    func playOnce(url: URL) {
+        if let p = try? makePlayer(url: url) {
+            hold = p
+            playOnMain(p)
         }
     }
 }

--- a/tictak/GameViewModel.swift
+++ b/tictak/GameViewModel.swift
@@ -36,6 +36,9 @@ final class GameViewModel: ObservableObject {
     @Published var hasGameStarted: Bool = false
     
     func startNewGame() {
+        // stop any win/lose/draw sound that might still be playing
+        audioService.stopNonMoveSounds()
+        
         selectedDifficulty = .easy
         needsDifficultySelection = false
         resetGame()


### PR DESCRIPTION
 found that move sounds were sometimes late or didn’t play at all. To fix this, I set up the audio session once, reused a small pool of players for move sounds, and ensured playback happens on the main thread with prepareToPlay. This makes the move SFX line up with the X/O appearing.

I also added a method to stop win/lose/draw sounds and call it when starting a new game, so end sounds don’t keep playing into the next round.

Changes are focused in AudioService (pooling, one-time session, stopNonMoveSounds) plus a small call in GameViewModel.startNewGame(). No UI or game logic changes.